### PR TITLE
feat: add password reset feature via Resend email

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,46 @@
+class PasswordResetsController < ApplicationController
+  before_action :load_golfer_by_token, only: [:edit, :update]
+
+  def new
+  end
+
+  def create
+    golfer = Golfer.find_by(email: params[:email].downcase.strip)
+    if golfer
+      golfer.generate_password_reset_token!
+      GolferMailer.password_reset(golfer).deliver_now
+    end
+    flash[:notice] = "If that email is registered, you'll receive a reset link shortly."
+    redirect_to "/login"
+  end
+
+  def edit
+  end
+
+  def update
+    if @golfer.password_reset_expired?
+      flash[:error] = "That reset link has expired. Please request a new one."
+      redirect_to "/forgot_password"
+    elsif @golfer.update(password_params)
+      @golfer.update_columns(password_reset_token: nil, password_reset_sent_at: nil)
+      flash[:notice] = "Password updated! Please log in."
+      redirect_to "/login"
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def load_golfer_by_token
+    @golfer = Golfer.find_by(password_reset_token: params[:token])
+    unless @golfer
+      flash[:error] = "Invalid or expired reset link."
+      redirect_to "/forgot_password"
+    end
+  end
+
+  def password_params
+    params.require(:golfer).permit(:password, :password_confirmation)
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'KPC <noreply@kitchenpassclassic.com>'
   layout 'mailer'
 end

--- a/app/mailers/golfer_mailer.rb
+++ b/app/mailers/golfer_mailer.rb
@@ -1,0 +1,7 @@
+class GolferMailer < ApplicationMailer
+  def password_reset(golfer)
+    @golfer = golfer
+    @reset_url = edit_password_reset_url(@golfer.password_reset_token)
+    mail(to: @golfer.email, subject: "KPC Password Reset")
+  end
+end

--- a/app/models/golfer.rb
+++ b/app/models/golfer.rb
@@ -72,4 +72,14 @@ class Golfer < ApplicationRecord
     trip_night_calendar(trip_id).length == 7 &&
     trip_round_calendar(trip_id).length == 6
   end
+
+  def generate_password_reset_token!
+    self.password_reset_token = SecureRandom.urlsafe_base64
+    self.password_reset_sent_at = Time.zone.now
+    save!(validate: false)
+  end
+
+  def password_reset_expired?
+    password_reset_sent_at < 2.hours.ago
+  end
 end

--- a/app/views/golfer_mailer/password_reset.html.erb
+++ b/app/views/golfer_mailer/password_reset.html.erb
@@ -1,0 +1,5 @@
+<h2>KPC Password Reset</h2>
+<p>Hey <%= @golfer.nickname %>,</p>
+<p>Someone requested a password reset for your KPC account. Click the link below to set a new password. This link expires in 2 hours.</p>
+<p><a href="<%= @reset_url %>">Reset My Password</a></p>
+<p>If you didn't request this, you can ignore this email.</p>

--- a/app/views/golfer_mailer/password_reset.text.erb
+++ b/app/views/golfer_mailer/password_reset.text.erb
@@ -1,0 +1,9 @@
+KPC Password Reset
+
+Hey <%= @golfer.nickname %>,
+
+Someone requested a password reset for your KPC account. Visit the link below to set a new password. This link expires in 2 hours.
+
+<%= @reset_url %>
+
+If you didn't request this, you can ignore this email.

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,88 @@
+<style>
+body {
+    display: flex;
+    background: url(<%= asset_path 'course_4.jpeg' %>);
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+}
+
+.auth-form-container, .login-form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 30px;
+    padding: 50px;
+    font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande',
+      'Lucida Sans', Arial, sans-serif;
+    color: black;
+    background-color: white;
+    opacity: 0.8;
+    border-radius: 25px;
+}
+
+label {
+    text-align: left;
+    padding: 0.25rem 0;
+}
+
+input {
+    margin: 0.25rem 0;
+    padding: .5rem;
+}
+
+button {
+    margin: 1rem 0;
+    background-color: #fff;
+    padding: 20px;
+    cursor: pointer;
+    border-radius: 10px;
+}
+
+.auth-form-container > h1 {
+    font-size: 60px;
+    text-align: center;
+}
+
+.error-message {
+    color: red;
+    margin: 0.25rem 0;
+}
+</style>
+
+<div class="auth-form-container">
+    <% flash.each do |name, msg| %>
+        <div class="alert" role="alert">
+            <%= content_tag :div, msg, class: name %>
+        </div>
+    <% end %>
+    <h1>RESET PASSWORD</h1>
+    <div class="login-form">
+        <% if @golfer.errors.any? %>
+            <% @golfer.errors.full_messages.each do |msg| %>
+                <p class="error-message"><%= msg %></p>
+            <% end %>
+        <% end %>
+        <%= form_with url: password_reset_path(params[:token]), method: :patch, local: true do |form| %>
+            <div class="label">
+                <%= form.label :password, "New Password" %>
+            </div>
+            <div class="input">
+                <%= form.password_field :password, name: "golfer[password]" %><br>
+            </div>
+            <div class="label">
+                <%= form.label :password_confirmation, "Confirm New Password" %>
+            </div>
+            <div class="input">
+                <%= form.password_field :password_confirmation, name: "golfer[password_confirmation]" %><br>
+            </div>
+            <div class="button">
+                <%= form.submit "Update Password" %>
+            </div>
+        <% end %>
+    </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,81 @@
+<style>
+body {
+    display: flex;
+    background: url(<%= asset_path 'course_4.jpeg' %>);
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+}
+
+.auth-form-container, .login-form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 30px;
+    padding: 50px;
+    font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande',
+      'Lucida Sans', Arial, sans-serif;
+    color: black;
+    background-color: white;
+    opacity: 0.8;
+    border-radius: 25px;
+}
+
+label {
+    text-align: left;
+    padding: 0.25rem 0;
+}
+
+input {
+    margin: 0.25rem 0;
+    padding: .5rem;
+}
+
+button {
+    margin: 1rem 0;
+    background-color: #fff;
+    padding: 20px;
+    cursor: pointer;
+    border-radius: 10px;
+}
+
+.auth-form-container > h1 {
+    font-size: 60px;
+    text-align: center;
+}
+
+.back-link {
+    margin-top: 1rem;
+    color: #333;
+    text-decoration: underline;
+    cursor: pointer;
+}
+</style>
+
+<div class="auth-form-container">
+    <% flash.each do |name, msg| %>
+        <div class="alert" role="alert">
+            <%= content_tag :div, msg, class: name %>
+        </div>
+    <% end %>
+    <h1>FORGOT PASSWORD</h1>
+    <div class="login-form">
+        <p>Enter your email and we'll send you a reset link.</p>
+        <%= form_with url: "/password_resets", method: :post, local: true do |form| %>
+            <div class="label">
+                <%= form.label :email %>
+            </div>
+            <div class="input">
+                <%= form.email_field :email %><br>
+            </div>
+            <div class="button">
+                <%= form.submit "Send Reset Link" %>
+            </div>
+        <% end %>
+        <a class="back-link" href="/login">Back to Login</a>
+    </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -91,5 +91,6 @@ button {
                     <%= form.submit "Log In" %>
                 </div>
             <% end %>
+            <%= link_to "Forgot Password?", "/forgot_password", style: "color: #333; margin-top: 0.5rem;" %>
         </div>
     </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,8 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,6 +64,15 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "kpc_#{Rails.env}"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.resend.com",
+    port: 587,
+    authentication: :plain,
+    user_name: "resend",
+    password: ENV["RESEND_API_KEY"]
+  }
+  config.action_mailer.default_url_options = { host: "kitchenpassclassic.com", protocol: "https" }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,9 @@ Rails.application.routes.draw do
   post "/payments", to: "payments#create"
 
   get "/finances", to: "finances#index"
+
+  get   "/forgot_password",             to: "password_resets#new"
+  post  "/password_resets",             to: "password_resets#create"
+  get   "/password_resets/:token/edit", to: "password_resets#edit",   as: :edit_password_reset
+  patch "/password_resets/:token",      to: "password_resets#update", as: :password_reset
 end

--- a/db/migrate/20260218210054_add_password_reset_to_golfers.rb
+++ b/db/migrate/20260218210054_add_password_reset_to_golfers.rb
@@ -1,0 +1,6 @@
+class AddPasswordResetToGolfers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :golfers, :password_reset_token, :string
+    add_column :golfers, :password_reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_05_145637) do
+ActiveRecord::Schema.define(version: 2026_02_18_210054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,8 @@ ActiveRecord::Schema.define(version: 2024_08_05_145637) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "nickname"
+    t.string "password_reset_token"
+    t.datetime "password_reset_sent_at"
   end
 
   create_table "nights", force: :cascade do |t|


### PR DESCRIPTION
Implements a full forgot-password flow: token generation, expiry (2h), GolferMailer with HTML/text templates, and PasswordResetsController. Configures ActionMailer with Resend SMTP for production and :test for dev. Sends from noreply@kitchenpassclassic.com.