### PR TITLE
refactor: replace hardcoded next trip query with Trip.current using E…

### DIFF
--- a/app/controllers/golfer_trips_controller.rb
+++ b/app/controllers/golfer_trips_controller.rb
@@ -3,7 +3,7 @@ class GolferTripsController < ApplicationController
   before_action :require_admin,  only: [:update]
 
   def new
-    @next_trip = Trip.where('start_date > ?', Date.today).first
+    @next_trip = Trip.current
     if current_user.is_registered_for_next_trip(@next_trip)
       flash[:login] = "You're already signed up, Fucko!"
       redirect_to "/dashboard"
@@ -14,7 +14,7 @@ class GolferTripsController < ApplicationController
 
   def create
     golfer = current_user
-    trip = Trip.where('start_date > ?', Date.today).first
+    trip = Trip.current
     golfer_trip = GolferTripFacade.create_new_golfer_trip(golfer, trip, params)
 
     if golfer_trip.save

--- a/app/controllers/golfers_controller.rb
+++ b/app/controllers/golfers_controller.rb
@@ -3,7 +3,7 @@ class GolfersController < ApplicationController
 
   def show
     @golfer = current_user
-    @next_trip = Trip.where('start_date > ?', Date.today).first
+    @next_trip = Trip.current
     @golfer_next_trip = @golfer.golfer_trips.where(trip_id: @next_trip.id).first
   end
 

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -4,6 +4,10 @@ class Trip < ApplicationRecord
   has_many :golfer_trips
   has_many :golfers, through: :golfer_trips
 
+  def self.current
+    where(number: ENV['CURRENT_TRIP_NUMBER']).first
+  end
+
   def sort_by_calendar
     calendar = []
     nights.each do |night|


### PR DESCRIPTION
…NV var

Replace Trip.where('start_date > ?', Date.today).first with Trip.current class method driven by CURRENT_TRIP_NUMBER env var, preventing the app from breaking when admins need to review finances during an active trip.